### PR TITLE
[refactor/auth] 인증/인가 리팩토링

### DIFF
--- a/src/main/java/gighub/worketserver/domain/OauthToken.java
+++ b/src/main/java/gighub/worketserver/domain/OauthToken.java
@@ -23,9 +23,8 @@ public class OauthToken {
   @Column(name = "token_id")
   private Long tokenId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id", nullable = false)
-  private User user;
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "provider", nullable = false)
@@ -58,7 +57,18 @@ public class OauthToken {
     this.accessToken = accessToken;
   }
 
-  public void setRefreshTokenExpiresAt(LocalDateTime refreshExpiresAt) {
+  public void updateRefreshTokenExpiresAt(LocalDateTime refreshExpiresAt) {
     this.refreshExpiresAt = refreshExpiresAt;
+  }
+
+  public void updateRefreshToken(String refreshToken) {
+    this.refreshToken = refreshToken;
+  }
+
+  public static OauthToken create(Long userId, Provider provider) {
+    OauthToken token = new OauthToken();
+    token.userId = userId;
+    token.provider = provider;
+    return token;
   }
 }

--- a/src/main/java/gighub/worketserver/domain/User.java
+++ b/src/main/java/gighub/worketserver/domain/User.java
@@ -66,10 +66,23 @@ public class User {
     }
   }
 
-  private String generateRandomPhone() {
+  private static String generateRandomPhone() {
     int mid = (int) (Math.random() * 9000) + 1000; // 1000~9999
     int end = (int) (Math.random() * 9000) + 1000; // 1000~9999
     return String.format("010-%04d-%04d", mid, end);
+  }
+
+  public static User create(Provider provider, String oauthId, String name, Role role) {
+    return User.builder()
+      .provider(provider)
+      .oauthId(oauthId)
+      .name(name)
+      .role(role)
+      .status(Status.ACTIVE)
+      .phone(generateRandomPhone())
+      .createdAt(LocalDateTime.now())
+      .updatedAt(LocalDateTime.now())
+      .build();
   }
 
   public void updatePasscode(String encodedPasscode) {

--- a/src/main/java/gighub/worketserver/domain/User.java
+++ b/src/main/java/gighub/worketserver/domain/User.java
@@ -89,4 +89,8 @@ public class User {
     this.passcode = encodedPasscode;
     this.updatedAt = LocalDateTime.now();
   }
+
+  public void updateStatus(Status status) {
+    this.status = status;
+  }
 }

--- a/src/main/java/gighub/worketserver/domain/UserRefreshToken.java
+++ b/src/main/java/gighub/worketserver/domain/UserRefreshToken.java
@@ -20,9 +20,8 @@ public class UserRefreshToken {
   @Column(name = "refresh_token_id")
   private Long refreshTokenId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id", nullable = false)
-  private User user;
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
 
   @Column(name = "refresh_token", nullable = false, length = 512)
   private String refreshToken;
@@ -46,5 +45,15 @@ public class UserRefreshToken {
 
   public boolean isValid() {
     return !Boolean.TRUE.equals(isRevoked) && !isExpired();
+  }
+
+  public static UserRefreshToken create(Long userId, String refreshToken, LocalDateTime expiresAt) {
+    UserRefreshToken token = new UserRefreshToken();
+    token.userId = userId;
+    token.refreshToken = refreshToken;
+    token.issuedAt = LocalDateTime.now();
+    token.expiresAt = expiresAt;
+    token.isRevoked = false;
+    return token;
   }
 }

--- a/src/main/java/gighub/worketserver/global/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/gighub/worketserver/global/filter/TokenAuthenticationFilter.java
@@ -54,14 +54,17 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
             // refresh token 만료 임박 여부 확인 후 재발급 (잔여기간 1일 이하)
             if (refreshTokenService.isExpiringSoon(refreshToken, 24)) {
+
               String newRefreshToken = tokenProvider.reissueRefreshToken(refreshToken);
+
+              refreshTokenService.rotateRefreshToken(refreshToken, newRefreshToken);
 
               ResponseCookie refreshCookie = cookieUtil.createTokenCookie("refreshToken", newRefreshToken, 7 * 24 * 60 * 60);
               response.addHeader("Set-Cookie", refreshCookie.toString());
             }
           }
 
-        }  else {
+        } else {
           // 3. 두 토큰 모두 기간이 유효하지 않음 => 쿠키를 비워줌 => 다시 로그인 해야함
           throw new TokenException(TokenErrorCode.EXPIRED_TOKEN);  // 401
         }

--- a/src/main/java/gighub/worketserver/global/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/gighub/worketserver/global/security/service/CustomOAuth2UserService.java
@@ -86,11 +86,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
           ? Role.CLIENT
           : Role.FREELANCER;
 
-        User newUser = oAuth2UserInfo.toEntity(role);
-        newUser.setRole(role);
-
         Provider provider = Provider.valueOf(registrationId.toUpperCase());
-        newUser.setProvider(provider);
+        User newUser = User.create(
+          provider,
+          oAuth2UserInfo.oauthId(),
+          oAuth2UserInfo.name(),
+          role
+        );
 
         return userRepository.save(newUser);
       });
@@ -107,12 +109,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       : null;
 
     OauthToken oauthToken = oauthTokenRepository.findByUserIdAndProvider(userId, provider)
-      .orElseGet(() -> {
-        OauthToken newToken = new OauthToken();
-        newToken.setUserId(userId);
-        newToken.setProvider(provider);
-        return newToken;
-      });
+      .orElseGet(() -> OauthToken.create(userId, provider));
 
     oauthToken.updateTokens(accessToken, refreshToken, refreshExpires);
 

--- a/src/main/java/gighub/worketserver/repository/TransactionRepository.java
+++ b/src/main/java/gighub/worketserver/repository/TransactionRepository.java
@@ -11,20 +11,20 @@ import java.util.List;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
 
-  List<Transaction> findByFreelancerId(Long freelancerId);
+//  List<Transaction> findByFreelancerId(Long freelancerId);
 
-  @Query("SELECT t FROM Transaction t WHERE t.freelancer.id = :freelancerId " +
-    "AND YEAR(t.createdAt) = :year AND MONTH(t.createdAt) = :month")
-  List<Transaction> findByFreelancerIdAndYearMonth(
-    @Param("freelancerId") Long freelancerId,
-    @Param("year") int year,
-    @Param("month") int month
-  );
-
-  @Query("SELECT COUNT(t) FROM Transaction t WHERE t.freelancer.id = :freelancerId " +
-    "AND t.status = :status")
-  Long countByFreelancerIdAndStatus(
-    @Param("freelancerId") Long freelancerId,
-    @Param("status") TransactionStatus status
-  );
+//  @Query("SELECT t FROM Transaction t WHERE t.freelancer.id = :freelancerId " +
+//    "AND YEAR(t.createdAt) = :year AND MONTH(t.createdAt) = :month")
+//  List<Transaction> findByFreelancerIdAndYearMonth(
+//    @Param("freelancerId") Long freelancerId,
+//    @Param("year") int year,
+//    @Param("month") int month
+//  );
+//
+//  @Query("SELECT COUNT(t) FROM Transaction t WHERE t.freelancer.id = :freelancerId " +
+//    "AND t.status = :status")
+//  Long countByFreelancerIdAndStatus(
+//    @Param("freelancerId") Long freelancerId,
+//    @Param("status") TransactionStatus status
+//  );
 }

--- a/src/main/java/gighub/worketserver/service/KakaoOauthService.java
+++ b/src/main/java/gighub/worketserver/service/KakaoOauthService.java
@@ -59,7 +59,9 @@ public class KakaoOauthService {
     }
   }
 
-  /** 카카오 연결 해제 */
+  /**
+   * 카카오 연결 해제
+   */
   public ApiResponse<String> unlink(HttpServletRequest request, HttpServletResponse response) {
     try {
       Long userId = extractUserIdFromJwt(request);
@@ -75,8 +77,7 @@ public class KakaoOauthService {
       refreshTokenService.revokeAllRefreshTokens(userId);
 
       // 4. 사용자 상태 변경
-      // TODO: userService.updateUserStatus(userId, Status.DELETED);
-      log.info("User {} status should be updated to DELETED", userId);
+      userService.updateUserStatus(userId, Status.DELETED);
 
       // 5. 쿠키 삭제
       ResponseCookie clearAccessToken = cookieUtil.createTokenCookie("accessToken", "", 0);
@@ -103,7 +104,9 @@ public class KakaoOauthService {
     }
   }
 
-  /** JWT 쿠키에서 사용자 ID 추출 */
+  /**
+   * JWT 쿠키에서 사용자 ID 추출
+   */
   private Long extractUserIdFromJwt(HttpServletRequest request) {
     String jwt = null;
     if (request.getCookies() != null) {
@@ -120,7 +123,9 @@ public class KakaoOauthService {
     return Long.parseLong(auth.getName());
   }
 
-  /** DB에서 Kakao Access Token 조회 */
+  /**
+   * DB에서 Kakao Access Token 조회
+   */
   private String getKakaoAccessToken(Long userId) {
     String token = oauthTokenService.findOauthAccessToken(userId, Provider.KAKAO);
     if (token == null)
@@ -128,7 +133,9 @@ public class KakaoOauthService {
     return token;
   }
 
-  /** 카카오 API 호출 공통 메서드 */
+  /**
+   * 카카오 API 호출 공통 메서드
+   */
   private void callKakaoApi(String url, String kakaoAccessToken) {
     HttpHeaders headers = new HttpHeaders();
     headers.set("Authorization", "Bearer " + kakaoAccessToken);

--- a/src/main/java/gighub/worketserver/service/KakaoTokenRefreshService.java
+++ b/src/main/java/gighub/worketserver/service/KakaoTokenRefreshService.java
@@ -68,8 +68,8 @@ public class KakaoTokenRefreshService {
           ? LocalDateTime.now().plusSeconds(refreshExpiresIn)
           : null;
 
-        oauthToken.setRefreshToken(newRefreshToken);
-        oauthToken.setRefreshTokenExpiresAt(refreshExpiresAt);
+        oauthToken.updateRefreshToken(newRefreshToken);
+        oauthToken.updateRefreshTokenExpiresAt(refreshExpiresAt);
       }
 
       oauthTokenRepository.save(oauthToken);

--- a/src/main/java/gighub/worketserver/service/RefreshTokenService.java
+++ b/src/main/java/gighub/worketserver/service/RefreshTokenService.java
@@ -18,7 +18,9 @@ public class RefreshTokenService {
 
   private final UserRefreshTokenRepository userRefreshTokenRepository;
 
-  /** JWT Refresh Token 저장 또는 갱신 */
+  /**
+   * JWT Refresh Token 저장 또는 갱신
+   */
   @Transactional
   public void saveRefreshToken(Long userId, String refreshToken, LocalDateTime expiresAt) {
     // 기존 유효한 토큰이 있으면 revoke 처리
@@ -29,17 +31,14 @@ public class RefreshTokenService {
       });
 
     // 새 리프레시 토큰 저장
-    UserRefreshToken newToken = new UserRefreshToken();
-    newToken.setUserId(userId);
-    newToken.setRefreshToken(refreshToken);
-    newToken.setIssuedAt(LocalDateTime.now());
-    newToken.setExpiresAt(expiresAt);
-    newToken.setIsRevoked(false);
+    UserRefreshToken newToken = UserRefreshToken.create(userId, refreshToken, expiresAt);
 
     userRefreshTokenRepository.save(newToken);
   }
 
-  /** JWT Refresh Token 조회 */
+  /**
+   * JWT Refresh Token 조회
+   */
   @Transactional(readOnly = true)
   public String findRefreshTokenOrThrow(Long userId) {
     return userRefreshTokenRepository.findByUserIdAndIsRevokedFalse(userId)
@@ -47,14 +46,18 @@ public class RefreshTokenService {
       .orElseThrow(() -> new TokenException(TokenErrorCode.EXPIRED_TOKEN));
   }
 
-  /** JWT Refresh Token 검증 */
+  /**
+   * JWT Refresh Token 검증
+   */
   public boolean isValidRefreshToken(String refreshToken) {
     return userRefreshTokenRepository.findByRefreshTokenAndIsRevokedFalse(refreshToken)
       .map(UserRefreshToken::isValid)
       .orElse(false);
   }
 
-  /** 사용자의 모든 Refresh Token revoke (로그아웃 시) */
+  /**
+   * 사용자의 모든 Refresh Token revoke (로그아웃 시)
+   */
   @Transactional
   public void revokeAllRefreshTokens(Long userId) {
     userRefreshTokenRepository.findByUserIdAndIsRevokedFalse(userId)
@@ -82,12 +85,10 @@ public class RefreshTokenService {
     userRefreshTokenRepository.save(existing);
 
     // 3. 새 토큰 엔티티 생성 및 저장
-    UserRefreshToken newToken = new UserRefreshToken();
-    newToken.setUserId(existing.getUserId());
-    newToken.setRefreshToken(newRefreshToken);
-    newToken.setIssuedAt(LocalDateTime.now());
-    newToken.setExpiresAt(LocalDateTime.now().plusDays(7)); // 새 만료일
-    newToken.setIsRevoked(false);
+    Long userId = existing.getUserId();
+    LocalDateTime newExpiresAt = LocalDateTime.now().plusDays(7);
+
+    UserRefreshToken newToken = UserRefreshToken.create(userId, newRefreshToken, newExpiresAt);
 
     userRefreshTokenRepository.save(newToken);
   }

--- a/src/main/java/gighub/worketserver/service/UserService.java
+++ b/src/main/java/gighub/worketserver/service/UserService.java
@@ -3,6 +3,7 @@ package gighub.worketserver.service;
 import gighub.worketserver.domain.User;
 import gighub.worketserver.domain.constants.Gender;
 import gighub.worketserver.domain.constants.Role;
+import gighub.worketserver.domain.constants.Status;
 import gighub.worketserver.dto.UserDetailDto;
 import gighub.worketserver.dto.UserProfileDto;
 import gighub.worketserver.dto.UserUpdateDto;
@@ -83,5 +84,13 @@ public class UserService {
     // Mock: 사용자 정보 업데이트
     // TODO: User 엔티티에 업데이트 메서드 추가하여 변경
     log.info("User updated - businessRegistrationNumber: {}", request.getBusinessRegistrationNumber());
+  }
+
+  @Transactional
+  public void updateUserStatus(Long userId, Status status) {
+    User user = userRepository.findById(userId)
+      .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+    user.updateStatus(status);
   }
 }


### PR DESCRIPTION
<!-- (제목) [브랜치 명] 기능 설명 -->
<!-- (예시) [feature/setting] 초기세팅 -->

### ❗ 관련 이슈
close # 17
close # 19

### ✨ 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
- [ ] ~ 리프레쉬 토큰 재발급 FIX #17 
- [ ] ~ 엔티티에 @setter 제거 #19 

### 💬 PR Point
> - 코드를 변경한 이유와 결과
> - 어떤 위험이나 우려가 발견되었는지

#### ⭐ 어떤 부분에 리뷰어가 집중해야 하는지


### ⚠️ 그 외 팀원에게 알리고 싶은 내용
<!-- 팀원에게 알리고 싶은 내용을 작성해주세요 -->
## 교체
### 연관관계 매핑 해제
연관관계를 맺지 않아도 그저 id를 통해 언제든 조회할수있는데 굳이 연관관계를 맺어 
원치않는 엔티티를 다불러와야하고 복잡성이 증가 할 수 있다. 

참고: 
https://lorenzo-dee.blogspot.com/2021/06/changing-way-we-use-jpa.html


### 롬복 setter 제거로 무분별한 setter 방지를 위한 정적 팩토리 메소드 create 만듦

create()는 새로운 User 생성 의도를 명확하게 전달하는 메서드이름을 지어주었다.

정적 팩토리 메서드는 여러 이점이 있다. 

명확한 네이밍으로 의도를 전달할 수 있고 객체 생성을 캡슐화할 수 있다..

네이밍 컨벤션이 있으니 참고 
https://tecoble.techcourse.co.kr/post/2020-05-26-static-factory-method/

### set으로 된 메서드들 update라는 명확한 이름으로 변경
set으로 하면 의도를 이해하기 어렵다. 하지만 좀 더 명확한 이름을통해 의도를 분명히 드러낼 수 있다. 

참고: https://velog.io/@langoustine/setter-%EC%A7%80%EC%96%91-%EC%9D%B4%EC%9C%A0

## 현재 trancation 엔티티에 freelancer_id가 없었음 
그래서 레포지토리에 메서드들 작동안해서 시작이 안돼서 주석 했음


## 리프레쉬 토큰 재발급 
fix authenticationFilter에서 실수로 24시간 미만 시 리프레쉬 토큰 재발급 하는데 오래된 토큰과 새로운 토큰을 교환하는 과정이 없음 rotate 기능을 만들고 안써서 적용

### (선택) 스크린샷 / GIF / 화면 녹화
<!-- 필요시 구현한 화면의 사진이나 동작 결과를 포함해주세요-->

---

### ✅ Self-Checklist
- [ ]  가장 최신의 branch를 pull했나요?
- [ ]  base branch를 확인했나요?
- [ ]  코드컨벤션을 모두 지켰나요?
- [ ]  셀프 리뷰를 진행했나요?
- [ ]  한 개의 PR에 한가지 기능만 반영되었나요?

