### PR TITLE
[refactor/global-exception-handler] ~ 다른 브랜치에서 처리 ~

### DIFF
--- a/src/main/java/gighub/worketserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gighub/worketserver/global/exception/GlobalExceptionHandler.java
@@ -1,28 +1,26 @@
 package gighub.worketserver.global.exception;
 
-import org.springframework.http.ResponseEntity;
+import gighub.worketserver.global.response.ApiResponse;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
-public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+public class GlobalExceptionHandler {
 
-  /*
-   * Developer Custom Exception: 직접 정의한 RestApiException 에러 클래스에 대한 예외 처리
+  /**
+   * ErrorCode 기반 Custom Exception 처리
    */
   @ExceptionHandler(RestApiException.class)
-  protected ResponseEntity<ErrorResponse> handleCustomException(RestApiException ex) {
+  protected ApiResponse<?> handleRestApiException(RestApiException ex) {
     ErrorCode errorCode = ex.getErrorCode();
-    return handleExceptionInternal(errorCode);
+    return ApiResponse.error(errorCode.getMessage());
   }
 
-  ;
-
-  // handleExceptionInternal() 메소드를 오버라이딩해 응답 커스터마이징
-  private ResponseEntity<ErrorResponse> handleExceptionInternal(ErrorCode errorCode) {
-    return ResponseEntity
-      .status(errorCode.getHttpStatus().value())
-      .body(new ErrorResponse(errorCode));
+  /**
+   * 예상 못한 모든 예외 처리
+   */
+  @ExceptionHandler(Exception.class)
+  protected ApiResponse<?> handleException(Exception ex) {
+    return ApiResponse.error(ex.getMessage());
   }
 }


### PR DESCRIPTION
<!-- (제목) [브랜치 명] 기능 설명 -->
<!-- (예시) [feature/setting] 초기세팅 -->

### ❗ 관련 이슈
close #24

에러나면 api response로 반환은 해주지만 200ok 주고있음

### ✨ 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
- [ ] GLOBALEXCEPTION HANDLER로 모든 에러를 끌어오도록 처리하도록함  
- [ ] GlobalExceptionHanlder ResponseEntity 반환하던거 ApiResponse 로 수정
- [ ] GlobalExceptionHanlder  ApiResponse를 ResponseEntity로 감쌈.
- [ ] 에러 시 HTTP STATUS 본문에 추가
- [ ] 공통 예외 처리 시 customCode = "COMMON_0000" 반환하도록 함
- [ ] 추상 클래스 CustomException 추가

### 💬 PR Point
> - 코드를 변경한 이유와 결과
> - 어떤 위험이나 우려가 발견되었는지

#### ⭐ 어떤 부분에 리뷰어가 집중해야 하는지

https://www.notion.so/2af86273f51680f38856f196d61ef50c?source=copy_link
예외처리 흐름이 어떻게 되는지 선행 지식


백엔드 세팅할때 globalExceptionHandler ResponseEntity로 반환하게 되어있어서

일관된 예외처리를 못해주고 있어가지고 ApiResponse 타입으로 바꿔주었습니다

ResponseEntity로 감싸서 에러가 났음에도 200OK를 띄우던 문제를 수정했습니다.


# 예외 처리 사용법

## 공통예외처리를 하는 이유 : 일일이 Exception ErrorCode 다만들면 너무 오래걸려서.

공통적인 예외처리는 RestApiException과 CommonErrorCode 사용하면 됨

정말필요한거만 Custom해서 사용할 수 있도록함.


## 예시 

### 
throw new RestApiException(CommonErrorCode.BAD_REQUEST, "유저를 찾을 수 없습니다.");

# 커스텀 예외 처리 사용법

지금 CustomException이라는 추상 클래스를 GlobalExceptionHandler에서 예외를 받도록 등록해서 사용하고 있음
CustomException 구현해서 사용하면 자동으로 처리해줍니다.


### ⚠️ 그 외 팀원에게 알리고 싶은 내용
<!-- 팀원에게 알리고 싶은 내용을 작성해주세요 -->

### (선택) 스크린샷 / GIF / 화면 녹화
<!-- 필요시 구현한 화면의 사진이나 동작 결과를 포함해주세요-->

CUSTOMEXCEPTION이 아닐 시 customCode = COMMON_0000
null로하면 success에서도 null로 보입니다...
<img width="618" height="151" alt="image" src="https://github.com/user-attachments/assets/7279da35-3eb9-4ac1-bb85-5037f0a7fe05" />

<img width="629" height="235" alt="image" src="https://github.com/user-attachments/assets/93286089-7e61-4494-a5e1-5b1c5d43742a" />

<img width="628" height="379" alt="image" src="https://github.com/user-attachments/assets/57c1b3fc-e4a6-4094-90e0-62e670958f76" />





---

### ✅ Self-Checklist
- [x]  가장 최신의 branch를 pull했나요?
- [x]  base branch를 확인했나요?
- [x]  코드컨벤션을 모두 지켰나요?
- [x]  셀프 리뷰를 진행했나요?
- [x]  한 개의 PR에 한가지 기능만 반영되었나요?

