### PR TITLE
[feature/oauth2-success-role-branch] 역할에 따른 분기 리다이렉트

### DIFF
--- a/src/main/java/gighub/worketserver/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/gighub/worketserver/global/security/handler/OAuth2SuccessHandler.java
@@ -1,5 +1,6 @@
 package gighub.worketserver.global.security.handler;
 
+import gighub.worketserver.global.security.repository.CustomAuthorizationRequestRepository;
 import gighub.worketserver.global.security.token.TokenProvider;
 import gighub.worketserver.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,10 +19,36 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
   private final TokenProvider tokenProvider;
   private final CookieUtil cookieUtil;
+  private final CustomAuthorizationRequestRepository customAuthorizationRequestRepository;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                       Authentication authentication) throws IOException {
+
+    // state 꺼내기
+    String rawState = customAuthorizationRequestRepository.getSavedState(request);
+
+    // state 파싱
+    String role = null;
+    String transactionId = null;
+
+    if (rawState != null && rawState.contains(":")) {
+      String[] parts = rawState.split(":");
+      role = parts[0];
+
+      if (parts.length > 1 && parts[1].startsWith("tx=")) {
+        transactionId = parts[1].substring(3);
+      }
+    }
+
+    String redirectUrl = "http://localhost:3000";
+
+    if ("client".equalsIgnoreCase(role) && transactionId != null) {
+      redirectUrl = "http://localhost:3000/trade/" + transactionId;
+    } else if ("freelancer".equalsIgnoreCase(role)) {
+      redirectUrl = "http://localhost:3000";
+    }
+
     // 로그인 성공 시 JWT 발급
     String accessToken = tokenProvider.generateAccessToken(authentication);
     String refreshToken = tokenProvider.generateRefreshToken(authentication);
@@ -34,6 +61,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     response.addHeader("Set-Cookie", accessCookie.toString());
     response.addHeader("Set-Cookie", refreshCookie.toString());
 
-    response.sendRedirect("http://localhost:3000");
+    response.sendRedirect(redirectUrl);
   }
 }

--- a/src/main/java/gighub/worketserver/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/gighub/worketserver/global/security/handler/OAuth2SuccessHandler.java
@@ -3,6 +3,7 @@ package gighub.worketserver.global.security.handler;
 import gighub.worketserver.global.security.repository.CustomAuthorizationRequestRepository;
 import gighub.worketserver.global.security.token.TokenProvider;
 import gighub.worketserver.global.util.CookieUtil;
+import gighub.worketserver.global.util.StateParser;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   private final CookieUtil cookieUtil;
   private final CustomAuthorizationRequestRepository customAuthorizationRequestRepository;
 
+  // Redirect URL 상수
+  private static final String BASE_FRONT_URL = "http://localhost:3000";
+
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                       Authentication authentication) throws IOException {
@@ -29,24 +33,17 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String rawState = customAuthorizationRequestRepository.getSavedState(request);
 
     // state 파싱
-    String role = null;
-    String transactionId = null;
+    var parsed = StateParser.parse(rawState);
 
-    if (rawState != null && rawState.contains(":")) {
-      String[] parts = rawState.split(":");
-      role = parts[0];
+    String role = parsed.role();
+    String transactionId = parsed.transactionId();
 
-      if (parts.length > 1 && parts[1].startsWith("tx=")) {
-        transactionId = parts[1].substring(3);
-      }
-    }
-
-    String redirectUrl = "http://localhost:3000";
+    String redirectUrl = BASE_FRONT_URL;
 
     if ("client".equalsIgnoreCase(role) && transactionId != null) {
-      redirectUrl = "http://localhost:3000/trade/" + transactionId;
+      redirectUrl = BASE_FRONT_URL + "/trade/" + transactionId;
     } else if ("freelancer".equalsIgnoreCase(role)) {
-      redirectUrl = "http://localhost:3000";
+      redirectUrl = BASE_FRONT_URL;
     }
 
     // 로그인 성공 시 JWT 발급

--- a/src/main/java/gighub/worketserver/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/gighub/worketserver/global/security/handler/OAuth2SuccessHandler.java
@@ -7,6 +7,7 @@ import gighub.worketserver.global.util.StateParser;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -22,8 +23,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   private final CookieUtil cookieUtil;
   private final CustomAuthorizationRequestRepository customAuthorizationRequestRepository;
 
-  // Redirect URL 상수
-  private static final String BASE_FRONT_URL = "http://localhost:3000";
+  @Value("${frontend.base-url}")
+  private String baseFrontUrl;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -38,12 +39,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String role = parsed.role();
     String transactionId = parsed.transactionId();
 
-    String redirectUrl = BASE_FRONT_URL;
+    String redirectUrl = baseFrontUrl;
 
     if ("client".equalsIgnoreCase(role) && transactionId != null) {
-      redirectUrl = BASE_FRONT_URL + "/trade/" + transactionId;
+      redirectUrl = baseFrontUrl + "/trade/" + transactionId;
     } else if ("freelancer".equalsIgnoreCase(role)) {
-      redirectUrl = BASE_FRONT_URL;
+      redirectUrl = baseFrontUrl;
     }
 
     // 로그인 성공 시 JWT 발급

--- a/src/main/java/gighub/worketserver/global/security/repository/CustomAuthorizationRequestRepository.java
+++ b/src/main/java/gighub/worketserver/global/security/repository/CustomAuthorizationRequestRepository.java
@@ -17,6 +17,7 @@ public class CustomAuthorizationRequestRepository
   private final CookieUtil cookieUtil;
 
   private static final String STATE_COOKIE = "oauth_state";
+  private static final int STATE_COOKIE_MAX_AGE_SECONDS = 180;
 
   @Override
   public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
@@ -42,7 +43,7 @@ public class CustomAuthorizationRequestRepository
     var cookie = cookieUtil.createTokenCookie(
       STATE_COOKIE,
       state,
-      180 // 3분 유효
+      STATE_COOKIE_MAX_AGE_SECONDS
     );
 
     response.addHeader("Set-Cookie", cookie.toString());

--- a/src/main/java/gighub/worketserver/global/security/repository/CustomAuthorizationRequestRepository.java
+++ b/src/main/java/gighub/worketserver/global/security/repository/CustomAuthorizationRequestRepository.java
@@ -1,22 +1,27 @@
 package gighub.worketserver.global.security.repository;
 
+import gighub.worketserver.global.util.CookieUtil;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+@RequiredArgsConstructor
 @Component
-public class CustomAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+public class CustomAuthorizationRequestRepository
+  implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
-  private final Map<String, String> stateStore = new ConcurrentHashMap<>();
+  private final CookieUtil cookieUtil;
+
+  private static final String STATE_COOKIE = "oauth_state";
 
   @Override
   public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-    return (OAuth2AuthorizationRequest) request.getSession().getAttribute("OAUTH2_AUTH_REQUEST");
+    return (OAuth2AuthorizationRequest)
+      request.getSession().getAttribute("OAUTH2_AUTH_REQUEST");
   }
 
   @Override
@@ -28,9 +33,19 @@ public class CustomAuthorizationRequestRepository implements AuthorizationReques
       return;
     }
 
+    // OAuth2 요청 세션에 저장
     request.getSession().setAttribute("OAUTH2_AUTH_REQUEST", authorizationRequest);
+
+    // state를 쿠키에 저장
     String state = authorizationRequest.getState();
-    stateStore.put(request.getSession().getId(), state);
+
+    var cookie = cookieUtil.createTokenCookie(
+      STATE_COOKIE,
+      state,
+      180 // 3분 유효
+    );
+
+    response.addHeader("Set-Cookie", cookie.toString());
   }
 
   @Override
@@ -38,12 +53,28 @@ public class CustomAuthorizationRequestRepository implements AuthorizationReques
                                                                HttpServletResponse response) {
     OAuth2AuthorizationRequest req =
       (OAuth2AuthorizationRequest) request.getSession().getAttribute("OAUTH2_AUTH_REQUEST");
+
     request.getSession().removeAttribute("OAUTH2_AUTH_REQUEST");
+
+    // 쿠키 삭제
+    var deleteCookie = cookieUtil.createTokenCookie(
+      STATE_COOKIE,
+      "",
+      0
+    );
+    response.addHeader("Set-Cookie", deleteCookie.toString());
+
     return req;
   }
 
   public String getSavedState(HttpServletRequest request) {
-    return stateStore.get(request.getSession().getId());
+    if (request.getCookies() == null) return null;
+
+    for (Cookie cookie : request.getCookies()) {
+      if (STATE_COOKIE.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
+    }
+    return null;
   }
 }
-

--- a/src/main/java/gighub/worketserver/global/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/gighub/worketserver/global/security/service/CustomOAuth2UserService.java
@@ -7,6 +7,7 @@ import gighub.worketserver.domain.constants.Role;
 import gighub.worketserver.global.security.dto.OAuth2UserInfo;
 import gighub.worketserver.global.security.dto.PrincipalDetails;
 import gighub.worketserver.global.security.repository.CustomAuthorizationRequestRepository;
+import gighub.worketserver.global.util.StateParser;
 import gighub.worketserver.repository.OauthTokenRepository;
 import gighub.worketserver.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -83,11 +84,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     return userRepository.findByOauthId(oAuth2UserInfo.oauthId())
       .orElseGet(() -> {
 
-        // state = "client:tx=1234" 일 때 "client" 부분만 추출
-        String rolePart = null;
-        if (state != null && state.contains(":")) {
-          rolePart = state.split(":")[0];   // "client"
-        }
+        var parsed = StateParser.parse(state);
+        String rolePart = parsed.role();
 
         Role role = ("CLIENT".equalsIgnoreCase(rolePart))
           ? Role.CLIENT

--- a/src/main/java/gighub/worketserver/global/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/gighub/worketserver/global/security/service/CustomOAuth2UserService.java
@@ -82,7 +82,14 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   private User getOrSave(OAuth2UserInfo oAuth2UserInfo, String state, String registrationId) {
     return userRepository.findByOauthId(oAuth2UserInfo.oauthId())
       .orElseGet(() -> {
-        Role role = ("CLIENT".equalsIgnoreCase(state))
+
+        // state = "client:tx=1234" 일 때 "client" 부분만 추출
+        String rolePart = null;
+        if (state != null && state.contains(":")) {
+          rolePart = state.split(":")[0];   // "client"
+        }
+
+        Role role = ("CLIENT".equalsIgnoreCase(rolePart))
           ? Role.CLIENT
           : Role.FREELANCER;
 

--- a/src/main/java/gighub/worketserver/global/util/StateParser.java
+++ b/src/main/java/gighub/worketserver/global/util/StateParser.java
@@ -1,0 +1,34 @@
+package gighub.worketserver.global.util;
+
+public class StateParser {
+
+  public record ParsedState(String role, String transactionId) {
+  }
+
+  /**
+   * state 예: "client:tx=1234"
+   * - role = "client"
+   * - transactionId = "1234"
+   */
+  public static ParsedState parse(String rawState) {
+    if (rawState == null || rawState.isBlank()) {
+      return new ParsedState(null, null);
+    }
+
+    String role = null;
+    String txId = null;
+
+    String[] parts = rawState.split(":");
+
+    if (parts.length >= 1 && !parts[0].isBlank()) {
+      role = parts[0];  // "client" or "freelancer"
+    }
+
+    if (parts.length >= 2 && parts[1].startsWith("tx=")) {
+      txId = parts[1].substring(3);   // "1234"
+    }
+
+    return new ParsedState(role, txId);
+  }
+}
+

--- a/src/main/resources/application-config.yml
+++ b/src/main/resources/application-config.yml
@@ -30,3 +30,6 @@ gemini:
   secret: ${GEMINI_SECRET}
   model: ${GEMINI_MODEL}
   url: ${GEMINI_URL}
+
+frontend:
+  base-url: ${FRONTEND_BASE_URL}


### PR DESCRIPTION
<!-- (제목) [브랜치 명] 기능 설명 -->
<!-- (예시) [feature/setting] 초기세팅 -->

### ❗ 관련 이슈
close #39

### ✨ 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
- [x] login 할 때 transactionId 쿼리파라미터로 받을 수 있게 함
- [x] ~ state 저장한거 로그인 성공 시 리다이렉트 할 때 사용할 수 있도록 CustomAuthorizationRequestRepository 구조 변경

### 💬 PR Point
> - 코드를 변경한 이유와 결과
> - 어떤 위험이나 우려가 발견되었는지

#### ⭐ 어떤 부분에 리뷰어가 집중해야 하는지


### ⚠️ 그 외 팀원에게 알리고 싶은 내용
<!-- 팀원에게 알리고 싶은 내용을 작성해주세요 -->

프론트에서 transactionid를

http://localhost:3000/login?state=client:tx=1234 형식으로 보내주면
로그인 성공 시 
http://localhost:3000/trade/1234 로 리다이렉트 시켜줌

### (선택) 스크린샷 / GIF / 화면 녹화
<!-- 필요시 구현한 화면의 사진이나 동작 결과를 포함해주세요-->

---

### ✅ Self-Checklist
- [ ]  가장 최신의 branch를 pull했나요?
- [ ]  base branch를 확인했나요?
- [ ]  코드컨벤션을 모두 지켰나요?
- [ ]  셀프 리뷰를 진행했나요?
- [ ]  한 개의 PR에 한가지 기능만 반영되었나요?

