### PR TITLE
[feature/passcode-role]  role에 따른 커스텀 에러 반환

### DIFF
--- a/src/main/java/gighub/worketserver/global/exception/PasscodeForFilterErrorCode.java
+++ b/src/main/java/gighub/worketserver/global/exception/PasscodeForFilterErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum PasscodeForFilterErrorCode implements ErrorCode {
-  PASSCODE_EMPTY(HttpStatus.FORBIDDEN, "AUTH_3001", "패스코드가 등록되지 않았습니다.");
+  PASSCODE_EMPTY(HttpStatus.FORBIDDEN, "AUTH_3001", "패스코드가 등록되지 않았습니다."),
+  PASSCODE_EMPTY_FREELANCER(HttpStatus.FORBIDDEN, "AUTH_3011", "프리랜서의 패스코드가 등록되지 않았습니다."),
+  PASSCODE_EMPTY_CLIENT(HttpStatus.FORBIDDEN, "AUTH_3021", "클라이언트의 패스코드가 등록되지 않았습니다.");
 
   private final HttpStatus httpStatus;
   private final String customCode;

--- a/src/main/java/gighub/worketserver/global/filter/PasscodeCheckFilter.java
+++ b/src/main/java/gighub/worketserver/global/filter/PasscodeCheckFilter.java
@@ -1,6 +1,7 @@
 package gighub.worketserver.global.filter;
 
 import gighub.worketserver.domain.User;
+import gighub.worketserver.domain.constants.Role;
 import gighub.worketserver.global.exception.PasscodeErrorCode;
 import gighub.worketserver.global.exception.PasscodeException;
 import gighub.worketserver.global.exception.PasscodeForFilterErrorCode;
@@ -44,7 +45,21 @@ public class PasscodeCheckFilter extends OncePerRequestFilter {
     PrincipalDetails details = (PrincipalDetails) auth.getPrincipal();
     User user = details.getUser();
 
+    Role role = user.getRole();
+
     if (user.getPasscode() == null || user.getPasscode().isBlank()) {
+
+      // 역할별 예외 코드 분기
+      if (role == Role.FREELANCER) {
+        request.setAttribute("exception", PasscodeForFilterErrorCode.PASSCODE_EMPTY_FREELANCER);
+        throw new PasscodeForFilterException(PasscodeForFilterErrorCode.PASSCODE_EMPTY_FREELANCER);
+      }
+
+      if (role == Role.CLIENT) {
+        request.setAttribute("exception", PasscodeForFilterErrorCode.PASSCODE_EMPTY_CLIENT);
+        throw new PasscodeForFilterException(PasscodeForFilterErrorCode.PASSCODE_EMPTY_CLIENT);
+      }
+
       request.setAttribute("exception", PasscodeForFilterErrorCode.PASSCODE_EMPTY);
       throw new PasscodeForFilterException(PasscodeForFilterErrorCode.PASSCODE_EMPTY);
     }

--- a/src/main/java/gighub/worketserver/global/filter/PasscodeCheckFilter.java
+++ b/src/main/java/gighub/worketserver/global/filter/PasscodeCheckFilter.java
@@ -49,19 +49,14 @@ public class PasscodeCheckFilter extends OncePerRequestFilter {
 
     if (user.getPasscode() == null || user.getPasscode().isBlank()) {
 
-      // 역할별 예외 코드 분기
-      if (role == Role.FREELANCER) {
-        request.setAttribute("exception", PasscodeForFilterErrorCode.PASSCODE_EMPTY_FREELANCER);
-        throw new PasscodeForFilterException(PasscodeForFilterErrorCode.PASSCODE_EMPTY_FREELANCER);
-      }
+      PasscodeForFilterErrorCode errorCode = switch (role) {
+        case FREELANCER -> PasscodeForFilterErrorCode.PASSCODE_EMPTY_FREELANCER;
+        case CLIENT -> PasscodeForFilterErrorCode.PASSCODE_EMPTY_CLIENT;
+        default -> PasscodeForFilterErrorCode.PASSCODE_EMPTY;
+      };
+      request.setAttribute("exception", errorCode);
+      throw new PasscodeForFilterException(errorCode);
 
-      if (role == Role.CLIENT) {
-        request.setAttribute("exception", PasscodeForFilterErrorCode.PASSCODE_EMPTY_CLIENT);
-        throw new PasscodeForFilterException(PasscodeForFilterErrorCode.PASSCODE_EMPTY_CLIENT);
-      }
-
-      request.setAttribute("exception", PasscodeForFilterErrorCode.PASSCODE_EMPTY);
-      throw new PasscodeForFilterException(PasscodeForFilterErrorCode.PASSCODE_EMPTY);
     }
 
     filterChain.doFilter(request, response);


### PR DESCRIPTION
<!-- (제목) [브랜치 명] 기능 설명 -->
<!-- (예시) [feature/setting] 초기세팅 -->

### ❗ 관련 이슈
close #50 

### ✨ 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
- [x] 📁 PasscodeForFilterErrorCode 
- 3011, 3021 커스텀 에러 추가
- [x] 📁 PasscodeCheckFilter
- role에 따른 에러 반환

### 💬 PR Point

커스텀 에러 추가
```java
  PASSCODE_EMPTY_FREELANCER(HttpStatus.FORBIDDEN, "AUTH_3011", "프리랜서의 패스코드가 등록되지 않았습니다."),
  PASSCODE_EMPTY_CLIENT(HttpStatus.FORBIDDEN, "AUTH_3021", "클라이언트의 패스코드가 등록되지 않았습니다.");
```


### (선택) 스크린샷 / GIF / 화면 녹화
<!-- 필요시 구현한 화면의 사진이나 동작 결과를 포함해주세요-->
<img width="682" height="298" alt="image" src="https://github.com/user-attachments/assets/da1704f5-9781-4424-bc8e-6a78398e280d" />
<img width="699" height="290" alt="image" src="https://github.com/user-attachments/assets/36433003-ef0b-47b9-b136-abd528cb23be" />

---

### ✅ Self-Checklist
- [ ]  가장 최신의 branch를 pull했나요?
- [ ]  base branch를 확인했나요?
- [ ]  코드컨벤션을 모두 지켰나요?
- [ ]  셀프 리뷰를 진행했나요?
- [ ]  한 개의 PR에 한가지 기능만 반영되었나요?

