### PR TITLE
[refactor/cookie-config-env] 쿠키 설정 환경변수로 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+.env
 .env.*
 
 ### NetBeans ###

--- a/src/main/java/gighub/worketserver/global/util/CookieUtil.java
+++ b/src/main/java/gighub/worketserver/global/util/CookieUtil.java
@@ -1,18 +1,33 @@
 package gighub.worketserver.global.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CookieUtil {
 
+  @Value("${COOKIE_DOMAIN:}")
+  private String cookieDomain;
+
+  @Value("${COOKIE_SAME_SITE:Lax}")
+  private String sameSite;
+
+  @Value("${COOKIE_SECURE:false}")
+  private boolean secure;
+
   public ResponseCookie createTokenCookie(String name, String value, long maxAgeSeconds) {
+    // 로컬에서는 domain 비움
+    String domainToSet = (cookieDomain == null || cookieDomain.isBlank())
+      ? null
+      : cookieDomain;
+
     return ResponseCookie.from(name, value)
       .httpOnly(true)
-      .secure(true)
-      .sameSite("None")
+      .secure(secure)
+      .sameSite(sameSite)
       .path("/")
-      .domain("worket.site")
+      .domain(domainToSet)
       .maxAge(maxAgeSeconds)
       .build();
   }

--- a/src/main/java/gighub/worketserver/global/util/CookieUtil.java
+++ b/src/main/java/gighub/worketserver/global/util/CookieUtil.java
@@ -17,11 +17,7 @@ public class CookieUtil {
   private boolean secure;
 
   public ResponseCookie createTokenCookie(String name, String value, long maxAgeSeconds) {
-    // 로컬에서는 domain 비움
-    String domainToSet = (cookieDomain == null || cookieDomain.isBlank())
-      ? null
-      : cookieDomain;
-
+    String domainToSet = cookieDomain.isBlank() ? null : cookieDomain;
     return ResponseCookie.from(name, value)
       .httpOnly(true)
       .secure(secure)

--- a/src/main/java/gighub/worketserver/global/util/StateCookieUtil.java
+++ b/src/main/java/gighub/worketserver/global/util/StateCookieUtil.java
@@ -1,6 +1,5 @@
 package gighub.worketserver.global.util;
 
-import net.minidev.json.JSONUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;

--- a/src/main/java/gighub/worketserver/global/util/StateCookieUtil.java
+++ b/src/main/java/gighub/worketserver/global/util/StateCookieUtil.java
@@ -14,12 +14,13 @@ public class StateCookieUtil {
   private boolean secure;
 
   public ResponseCookie createStateCookie(String name, String value, long maxAgeSeconds) {
+    String domainToSet = cookieDomain.isBlank() ? null : cookieDomain;
     return ResponseCookie.from(name, value)
       .httpOnly(true)
       .secure(secure)
-      .sameSite("Lax")     // 핵심: AuthorizationRequest state는 Lax여야 정상 작동
+      .sameSite("Lax")     // AuthorizationRequest state는 Lax여야 정상 작동
       .path("/")
-      .domain(cookieDomain)
+      .domain(domainToSet)
       .maxAge(maxAgeSeconds)
       .build();
   }

--- a/src/main/java/gighub/worketserver/global/util/StateCookieUtil.java
+++ b/src/main/java/gighub/worketserver/global/util/StateCookieUtil.java
@@ -1,20 +1,28 @@
 package gighub.worketserver.global.util;
 
+import net.minidev.json.JSONUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
 public class StateCookieUtil {
 
-  private static final String DOMAIN = "worket.site";
+  @Value("${COOKIE_DOMAIN:}")
+  private String cookieDomain;
+
+  @Value("${COOKIE_SECURE:false}")
+  private boolean secure;
 
   public ResponseCookie createStateCookie(String name, String value, long maxAgeSeconds) {
+    System.out.println("cookieDomain: " + cookieDomain);
+    System.out.println("secure: " + secure);
     return ResponseCookie.from(name, value)
       .httpOnly(true)
-      .secure(true)
-      .sameSite("Lax")     // ★ 핵심: AuthorizationRequest state는 Lax여야 정상 작동
+      .secure(secure)
+      .sameSite("Lax")     // 핵심: AuthorizationRequest state는 Lax여야 정상 작동
       .path("/")
-      .domain(DOMAIN)
+      .domain(cookieDomain)
       .maxAge(maxAgeSeconds)
       .build();
   }
@@ -22,10 +30,10 @@ public class StateCookieUtil {
   public ResponseCookie deleteStateCookie(String name) {
     return ResponseCookie.from(name, "")
       .httpOnly(true)
-      .secure(true)
+      .secure(secure)
       .sameSite("Lax")
       .path("/")
-      .domain(DOMAIN)
+      .domain(cookieDomain)
       .maxAge(0)
       .build();
   }

--- a/src/main/java/gighub/worketserver/global/util/StateCookieUtil.java
+++ b/src/main/java/gighub/worketserver/global/util/StateCookieUtil.java
@@ -15,8 +15,6 @@ public class StateCookieUtil {
   private boolean secure;
 
   public ResponseCookie createStateCookie(String name, String value, long maxAgeSeconds) {
-    System.out.println("cookieDomain: " + cookieDomain);
-    System.out.println("secure: " + secure);
     return ResponseCookie.from(name, value)
       .httpOnly(true)
       .secure(secure)


### PR DESCRIPTION
<!-- (제목) [브랜치 명] 기능 설명 -->
<!-- (예시) [feature/setting] 초기세팅 -->

### ❗ 관련 이슈
close # 

### ✨ 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
- [x] `CookieUtil`, `StateCookieUtil`에서 쿠키 설정을 환경 변수로 분리했습니다.

### 💬 PR Point
> - 로컬 환경에서 테스트해보기 위한 환경 변수 분리가 필요합니다.
> - 현재는 쿠키를 내려주는 도메인이 배포된 사이트로 되어 있어 로컬 개발 시 테스트 진행이 어렵습니다.

#### ⭐ 어떤 부분에 리뷰어가 집중해야 하는지
환경변수로 분리된 부분이 잘 적용 되었는지, 기본값이 잘 설정되었는지 확인 부탁드립니다!

### ⚠️ 그 외 팀원에게 알리고 싶은 내용
<!-- 팀원에게 알리고 싶은 내용을 작성해주세요 -->
- .env.local 변경 있습니다. 슬랙 확인해주세요!

### (선택) 스크린샷 / GIF / 화면 녹화
<!-- 필요시 구현한 화면의 사진이나 동작 결과를 포함해주세요-->

---

### ✅ Self-Checklist
- [ ]  가장 최신의 branch를 pull했나요?
- [ ]  base branch를 확인했나요?
- [ ]  코드컨벤션을 모두 지켰나요?
- [ ]  셀프 리뷰를 진행했나요?
- [ ]  한 개의 PR에 한가지 기능만 반영되었나요?

